### PR TITLE
Update database-validation.mdx

### DIFF
--- a/docs/configuration/database-validation.mdx
+++ b/docs/configuration/database-validation.mdx
@@ -78,7 +78,7 @@ There are two ways to start validation:
 
 -   `NONE`: Don't validate database structure, this is the default behavior.
 
--   `WARNNING`: Validate database structure, if the database structure is inconsistent with the entity model definition, it does not prevent the program from running, just prints warning information in the log.
+-   `WARNING`: Validate database structure, if the database structure is inconsistent with the entity model definition, it does not prevent the program from running, just prints warning information in the log.
 
 -   `ERROR`: Validate database structure, if the database structure is inconsistent with the entity model definition, an exception will be thrown to prevent the program from running.
 


### PR DESCRIPTION
文档值是WARNNING实际值是WARNING
版本 jimmer-0.8.77

***************************
APPLICATION FAILED TO START
***************************

Description:

Failed to bind properties under 'jimmer.database-validation-mode' to org.babyfish.jimmer.sql.runtime.DatabaseValidationMode:

    Property: jimmer.database-validation-mode
    Value: "WARNNING"
    Origin: class path resource [application.yml] - 273:29
    Reason: failed to convert java.lang.String to @java.lang.Deprecated org.babyfish.jimmer.sql.runtime.DatabaseValidationMode (caused by java.lang.IllegalArgumentException: No enum constant org.babyfish.jimmer.sql.runtime.DatabaseValidationMode.WARNNING)

Action:

Update your application's configuration. The following values are valid:

    ERROR
    NONE
    WARNING