### PR TITLE
Fix the GeneratedValue annotation error in the BookStore code

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/quick-view/precondition.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/quick-view/precondition.mdx
@@ -63,7 +63,7 @@ public interface BookStore {
 interface BookStore {
 
     @Id
-    @@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long
 
     val name: String


### PR DESCRIPTION
There is an extra '@' in the annotation.