### PR TITLE
Typo fix

### DIFF
--- a/docs/quick-view/get-started/define-entity.mdx
+++ b/docs/quick-view/get-started/define-entity.mdx
@@ -285,7 +285,7 @@ Assume the entity package is "com.example.model". **Ignore associated properties
     - For Java:
         - Primitives like boolean, char, byte, short, int, long, float, double are non-null.
         - Boxed types like Boolean, Character, Byte, Short, Integer, Long, Float, Double are nullable.
-        - Other types are non-null by default. Add `@Nullable` to allow null.
+        - Other types are non-null by default. Add `@TNullable` to allow null.
 
 -   Annotations used in example:
     - `@Entity` - Indicates entity type.


### PR DESCRIPTION
Most likely, the intention was to reference [the `@TNullable` annotation](https://github.com/babyfish-ct/jimmer/blob/main/project/jimmer-core/src/main/java/org/babyfish/jimmer/client/TNullable.java).