### PR TITLE
Fixed the broken link to the input-dto problem

### DIFF
--- a/docs/object/view/dto-language.mdx
+++ b/docs/object/view/dto-language.mdx
@@ -19,7 +19,7 @@ However, not all DTO types can be eliminated. Input DTO objects are hard to remo
 
 > For example, in GraphQL, although dynamic `GraphQLObject` data is returned for the client from the output perspective, static `GraphQLInput` data submitted by the client is accepted from the input perspective.
 >
-> Why does the GraphQL protocol define `GraphQLInput` as a static type? Because API explicitness and system security are very important requirements, please refer to [Problems with dynamic objects as input parameters](../../mutation/save-command/input-dto/problem).
+> Why does the GraphQL protocol define `GraphQLInput` as a static type? Because API explicitness and system security are very important requirements, please refer to [Problems with dynamic objects as input parameters](/docs/mutation/save-command/input-dto/problem).
 >
 > The problems faced by the GraphQL protocol are also faced by Jimmer, which must provide a complete solution.
 


### PR DESCRIPTION
On the [DTO Language page](https://babyfish-ct.github.io/jimmer-doc/docs/object/view/dto-language/), there is a link to `input-dto/problem.mdx`:

> Why does the GraphQL protocol define GraphQLInput as a static type? Because API explicitness and system security are very important requirements, please refer to [Problems with dynamic objects as input parameters](https://babyfish-ct.github.io/jimmer-doc/docs/object/mutation/save-command/input-dto/problem).

This link is broken. This PR is trying to fix that