### PR TITLE
Fix explanation(EN ver) mismatch for the figure of  "Save Command"

### DIFF
--- a/src/components/HomepageFeatures/SaveCommand.tsx
+++ b/src/components/HomepageFeatures/SaveCommand.tsx
@@ -147,10 +147,10 @@ const EN =
                         <span style={{color:"blue"}}>Blue parts</span>: For entity objects that exist in both new and old data structures, modify associations if they have changed
                     </li>
                     <li>
-                        <span style={{color:"green"}}>Green parts</span>: For entity objects that exist in the old data structure but not in the new one, decouple this object, clear associations and possibly delete data
+                        <span style={{color:"green"}}>Green parts</span>: For entity objects that exist in the new data structure but not in the old one, insert data and establish associations
                     </li>
                     <li>
-                        <span style={{color:"red"}}>Red parts</span>: For entity objects that exist in the new data structure but not in the old one, insert data and establish associations
+                        <span style={{color:"red"}}>Red parts</span>: For entity objects that exist in the old data structure but not in the new one, decouple this object, clear associations and possibly delete data
                     </li>
                 </ul>
             </li>


### PR DESCRIPTION
## Description
There is a small issue in the English version of the explanation for the figure at [this link](https://babyfish-ct.github.io/jimmer-doc/docs/mutation/save-command/usage/#introduction). The content under the "Green Parts" section should be moved under the "Red Parts" section, and vice versa[^5^].

## Screenshots
### English Version (wrong)
![English Version with Highlighted Issues](https://github.com/user-attachments/assets/fb209293-4b66-4b69-9794-af73d37c7459)

###  Compare to Chinese Version (correct)
![Chinese Version](https://github.com/user-attachments/assets/cf22a134-60b5-48dc-a2fa-4a2dae1383c9)
>The images are hosted on GitHub. If they are not accessible, please let me know

## Proposed Changes
- Rearrange the content under the "Green Parts" and "Red Parts" sections to correct the order.