### PR TITLE
替换kotlin下配置KsqlClient写法为kotlin 而不是Java

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/configuration/multi-datasources.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/configuration/multi-datasources.mdx
@@ -163,8 +163,8 @@ public class SqlClientConfig {
         )
 
     @Bean
-    public JSqlClient sqlClient() = ❸
-        TransactionalSqlClients.kotlin()
+    fun sqlClient(): KSqlClient = TransactionalSqlClients.kotlin() ❸
+
 }
 ```
 


### PR DESCRIPTION
替换kotlin下配置KsqlClient写法为kotlin 而不是Java