### PR TITLE
修复entity.mdx中的数据类型错误：将UUID改为LocalDateTime

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/current/mapping/advanced/logical-deleted/entity.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/mapping/advanced/logical-deleted/entity.mdx
@@ -283,7 +283,7 @@ Nullable LocalDateTime
 ```java
 @Nullable
 @LogicalDeleted("now")
-UUID deletedTime();
+LocalDateTime deletedTime();
 ```
 
 </TabItem>
@@ -309,7 +309,7 @@ val deletedTime: LocalDateTime?
 ```java
 @Nullable
 @LogicalDeleted("null")
-UUID createdTime();
+LocalDateTime createdTime();
 ```
 
 </TabItem>


### PR DESCRIPTION
## 修改说明
修复了entity.mdx文件中的数据类型错误：

### 变更内容
- 将 `deletedTime()` 的返回类型从 `UUID` 改为 `LocalDateTime`
- 将 `createdTime()` 的返回类型从 `UUID` 改为 `LocalDateTime`

### 修改原因
时间字段应该使用 `LocalDateTime` 类型而不是 `UUID` 类型。

### 影响范围
- 仅影响文档内容，不涉及代码逻辑
- 修正了文档中的错误示例