### PR TITLE
improve: Add version badges for the reference version

### DIFF
--- a/docs/_shared/precompiler.mdx
+++ b/docs/_shared/precompiler.mdx
@@ -1,9 +1,12 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 You can use either Jimmer's standard build method, or use plugins provided by the community.
 
 -   Method 1: Use Jimmer's standard build method
+
+    <VersionBadgeAdmonition />
 
     <Tabs groupId="buildTool">
     <TabItem value="java_maven" label="Java (Maven)">

--- a/docs/_shared/version.md
+++ b/docs/_shared/version.md
@@ -1,6 +1,10 @@
-:::info
+import { VersionBadge } from '@site/src/components/VersionBadge';
+
+::::info
 Please replace ·TODO: latest.version· in the code below with the really version number. 
 
 Please refer to https://github.com/babyfish-ct/jimmer/releases, find the latest release from there, remove the leading `v`, and the rest part is the really version number.
 For example, if the last release on this page is `v0.9.64`, then the actual version number is `0.9.64`.
-:::
+
+<VersionBadge />
+::::

--- a/docs/graphql/concept.mdx
+++ b/docs/graphql/concept.mdx
@@ -5,6 +5,7 @@ title: Basic Concepts
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## Concepts
 
@@ -20,6 +21,8 @@ Therefore, it is not possible to expose functionality like [recursive queries in
 
 Jimmer's support for GraphQL is based on [Spring GraphQL](https://spring.io/projects/spring-graphql).
 So the project needs to import both the Jimmer and Spring GraphQL Spring Boot starters, for example:
+
+<VersionBadgeAdmonition />
 
 <Tabs groupId="buildTool">
 <TabItem value="maven" label="Maven">

--- a/docs/object/view/mapstruct.mdx
+++ b/docs/object/view/mapstruct.mdx
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { ShortAssociation } from '@site/src/components/ShortAssociation';
 import { ViewMore } from '@site/src/components/ViewMore';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## Introduction
 
@@ -76,6 +77,8 @@ You can use either Jimmer's standard build method, or use plugins provided by th
 
 -   Method 1: Use Jimmer's standard build method
 
+    <VersionBadgeAdmonition />
+
     <Tabs groupId="buildTool">
     <TabItem value="java_maven" label="Java(Maven)">
 
@@ -132,7 +135,7 @@ You can use either Jimmer's standard build method, or use plugins provided by th
 
     ```groovy title="build.gradle"
     dependencies {
-        
+
         implementation "org.projectlombok:lombok:${lombok.version}" ➀
         implementation "org.mapstruct:mapstruct:${mapstructVersion}" ➊
 
@@ -156,7 +159,7 @@ You can use either Jimmer's standard build method, or use plugins provided by th
     }
 
     dependencies {
-        
+
         implementation("org.mapstruct:mapstruct:${mapstructVersion}") ➊
 
         ksp("org.babyfish.jimmer:jimmer-ksp:${jimmerVersion}") ➋
@@ -203,7 +206,7 @@ You can use either Jimmer's standard build method, or use plugins provided by th
 
         annotationProcessor "org.projectlombok:lombok:${lombok.version}" ➁
         annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}" ➍
-        
+
         // there's no need to add org.babyfish.jimmer:jimmer-apt to dependencies manually
         // when mapstruct-processor dependency is detected，the gradle plugin will add jimmer-apt to dependencies automatically
 
@@ -230,7 +233,7 @@ You can use either Jimmer's standard build method, or use plugins provided by th
     }
 
     dependencies {
-        
+
         implementation("org.mapstruct:mapstruct:${mapstructVersion}") ➊
         kapt("org.mapstruct:mapstruct-processor:${mapstructVersion}") ➌
 
@@ -352,14 +355,14 @@ Three properties of this POJO need to be explained:
 -   `BookInput.storeId` 
 
     This is obviously an associated id for the dynamic entity object property `Book.store`. 
-    
+
     This kind of dynamic object property is defined as an associated object, but in the POJO it is defined as an associated id, 
     called a <ViewMore buttonText="short association"><ShortAssociation/></ViewMore>.
 
 -   `BookInput.authorIds` 
-    
+
     This is obviously a collection of associated ids, for the dynamic entity object property `Book.authors`. 
-    
+
     This kind of dynamic object property is defined as an associated objects, but in the POJO it is defined as an associated ids, 
     called a <ViewMore buttonText="short association"><ShortAssociation/></ViewMore>.
 

--- a/docs/quick-view/get-started/create-project.mdx
+++ b/docs/quick-view/get-started/create-project.mdx
@@ -6,6 +6,7 @@ title: Create a Project
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Version from '../../_shared/version.md';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## Create a Spring Boot Project
 
@@ -186,6 +187,8 @@ jimmer:
 In addition to Jimmer, some other dependencies are required like spring-web, JDBC driver, etc.
 
 Modify build.gradle or pom.xml to add dependencies:
+
+<VersionBadgeAdmonition />
 
 <Tabs groupId="buildTool">
 <TabItem value="maven" label="Maven">

--- a/docs/quick-view/get-started/generate-code.mdx
+++ b/docs/quick-view/get-started/generate-code.mdx
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {GeneratedJava, GeneratedKt, Generated} from '@site/src/components/Image';
 import Precompiler from '../../_shared/precompiler.mdx';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## Code Generation
 
@@ -36,6 +37,8 @@ Jimmer data types require one of:
 The first is ORM-agnostic, the others are ORM-related.
 
 If entities use the ORM annotations *(eg: @Entity)*, the generated code requires `jimmer-sql` while entity code itself only needs `jimmer-core`:
+
+<VersionBadgeAdmonition />
 
 <Tabs groupId="buildTool">
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/_shared/precompiler.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/_shared/precompiler.mdx
@@ -1,9 +1,12 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 你既可以使用Jimmer标准的构建方式，也可以采用社区提供的插件
 
 -   用法一：使用Jimmer标准的构建方式
+
+    <VersionBadgeAdmonition />
 
     <Tabs groupId="buildTool">
     <TabItem value="java_maven" label="Java(Maven)">

--- a/i18n/zh/docusaurus-plugin-content-docs/current/_shared/version.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/_shared/version.md
@@ -1,7 +1,13 @@
+import { VersionBadge } from '@site/src/components/VersionBadge';
+
 :::info
+
 请把下面代码中的`TODO: latest.version`替换为真正的版本号。
 
 请参见https://github.com/babyfish-ct/jimmer/releases
 ，从中找到最新的release，去掉前面的`v`就得到了真正的版本号。
 例如，此页面中最后一个release为`v0.9.64`, 那么真正的版本号就是`0.9.64`。
+
+<VersionBadge />
+
 :::

--- a/i18n/zh/docusaurus-plugin-content-docs/current/graphql/concept.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/graphql/concept.mdx
@@ -5,6 +5,7 @@ title: 基本概念
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## 概念
 
@@ -20,6 +21,8 @@ import TabItem from '@theme/TabItem';
 
 Jimmer对GraphQL的支持基于[Spring GraphQL](https://spring.io/projects/spring-graphql)实现的。
 所以，项目需要同时导入Jimmer和Spring GraphQL的Spring Boot Starter，比如
+
+<VersionBadgeAdmonition />
 
 <Tabs groupId="buildTool">
 <TabItem value="maven" label="Maven">

--- a/i18n/zh/docusaurus-plugin-content-docs/current/object/view/mapstruct.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/object/view/mapstruct.mdx
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { ShortAssociation } from '@site/src/components/ShortAssociation';
 import { ViewMore } from '@site/src/components/ViewMore';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## 简介
 
@@ -75,6 +76,8 @@ Jimmer的实体对象是动态的 *(和Hibernate3引入的标量属性惰性化�
 你既可以使用Jimmer标准的构建方式，也可以采用社区提供的插件
 
 -   用法一：使用Jimmer标准的构建方式
+
+    <VersionBadgeAdmonition />
 
     <Tabs groupId="buildTool">
     <TabItem value="java_maven" label="Java(Maven)">

--- a/i18n/zh/docusaurus-plugin-content-docs/current/quick-view/get-started/create-project.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/quick-view/get-started/create-project.mdx
@@ -6,6 +6,7 @@ title: 创建项目
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Version from '../../_shared/version.md';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## 创建SpringBoot项目
 
@@ -184,6 +185,8 @@ jimmer:
 除了Jimmer外，还需要一些其他必要的依赖，比如spring-web，JDBC驱动。
 
 修改gradle或maven文件，加入依赖
+
+<VersionBadgeAdmonition />
 
 <Tabs groupId="buildTool">
 <TabItem value="maven" label="Maven">

--- a/i18n/zh/docusaurus-plugin-content-docs/current/quick-view/get-started/generate-code.mdx
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/quick-view/get-started/generate-code.mdx
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import {GeneratedJava, GeneratedKt, Generated} from '@site/src/components/Image';
 import Precompiler from '../../_shared/precompiler.mdx';
+import { VersionBadgeAdmonition } from '@site/src/components/VersionBadgeAdmonition';
 
 ## 代码生成
 
@@ -38,6 +39,8 @@ Jimmer定义数据类型需要如下4个注解之一
 一旦实体项目中有数据类型使用了后面三种注解中的任何，就会导致一个问题：用户编写的实体代码本身只需要依赖`jimmer-core`，但是代码生成器生成的代码需要依赖`jimmer-sql`。
 
 为解决这个问题，请如此配置依赖
+
+<VersionBadgeAdmonition />
 
 <Tabs groupId="buildTool">
 <TabItem value="java" label="Maven">

--- a/src/components/VersionBadge.tsx
+++ b/src/components/VersionBadge.tsx
@@ -1,0 +1,23 @@
+import React, {FC, memo} from "react";
+import {useZh} from "../util/use-zh";
+import Box from "@mui/material/Box";
+
+export const VersionBadge: FC = memo(() => {
+    const zh = useZh();
+
+    return (
+        <Box style={{display: 'inline-flex', alignItems: 'center'}}>
+            <span>{zh ? "当前版本参考: " : "Current version reference: "}</span>
+            <a
+                href="http://github.com/babyfish-ct/jimmer/releases"
+                target="_blank"
+                style={{paddingLeft: 5, display: 'inline-flex', alignItems: 'center'}}
+            >
+                <img
+                    src="https://img.shields.io/maven-central/v/org.babyfish.jimmer/jimmer-core"
+                    alt="Maven Central Version"
+                />
+            </a>
+        </Box>
+    );
+});

--- a/src/components/VersionBadgeAdmonition.tsx
+++ b/src/components/VersionBadgeAdmonition.tsx
@@ -1,0 +1,12 @@
+import React, {FC, memo} from "react";
+import Admonition from '@theme/Admonition';
+import {VersionBadge} from "./VersionBadge";
+
+
+export const VersionBadgeAdmonition: FC = memo(() => {
+    return (
+        <Admonition type="info">
+            <VersionBadge/>
+        </Admonition>
+    );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,11 +2184,7 @@
 
 "@easyops-cn/docusaurus-search-local@^0.46.1":
   version "0.46.1"
-<<<<<<< HEAD
-  resolved "https://registry.yarnpkg.com/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.46.1.tgz#7fac1a14417de680b5af7088814192a153d7334d"
-=======
   resolved "https://registry.npmmirror.com/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.46.1.tgz#7fac1a14417de680b5af7088814192a153d7334d"
->>>>>>> 80e7f8002ed39a2695b6cd492e48a984a2715ef9
   integrity sha512-kgenn5+pctVlJg8s1FOAm9KuZLRZvkBTMMGJvTTcvNTmnFIHVVYzYfA2Eg+yVefzsC8/cSZGKKJ0kLf8I+mQyw==
   dependencies:
     "@docusaurus/plugin-content-docs" "^2 || ^3"
@@ -4146,11 +4142,7 @@ combine-promises@^1.1.0:
 
 comlink@^4.4.2:
   version "4.4.2"
-<<<<<<< HEAD
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
-=======
   resolved "https://registry.npmmirror.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
->>>>>>> 80e7f8002ed39a2695b6cd492e48a984a2715ef9
   integrity sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==
 
 comma-separated-tokens@^2.0.0:


### PR DESCRIPTION
Add some version badges for reference versions like this: ![Maven Central Version](https://img.shields.io/maven-central/v/org.babyfish.jimmer/jimmer-core)

Make the parts of the document that depend on references more user-friendly.

The badge is from [shields.io](https://shields.io/badges/maven-central-version).