### PR TITLE
improve: GitHub Action behavior

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,8 +20,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - run: npm install -g yarn
-      - run: yarn install
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,6 +12,7 @@ jobs:
       contents: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -18,9 +18,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+          cache: 'yarn'
 
-      - run: npm install -g yarn
-      - run: yarn install
+      # https://classic.yarnpkg.com/en/docs/cli/install
+      - run: yarn install --frozen-lockfile
 
       # Only build to verify that it is available, not deploy
       - run: yarn build

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -4,9 +4,13 @@ on:
   pull_request:
     branches:
       - main
+
 jobs:
   test-build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: '${{ github.workflow }}-${{ github.ref }}'
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request-test.yml
+++ b/.github/workflows/pull-request-test.yml
@@ -1,0 +1,22 @@
+name: Build Test
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - main
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - run: npm install -g yarn
+      - run: yarn install
+
+      # Only build to verify that it is available, not deploy
+      - run: yarn build

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,11 +2184,7 @@
 
 "@easyops-cn/docusaurus-search-local@^0.46.1":
   version "0.46.1"
-<<<<<<< HEAD
-  resolved "https://registry.yarnpkg.com/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.46.1.tgz#7fac1a14417de680b5af7088814192a153d7334d"
-=======
   resolved "https://registry.npmmirror.com/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.46.1.tgz#7fac1a14417de680b5af7088814192a153d7334d"
->>>>>>> 80e7f8002ed39a2695b6cd492e48a984a2715ef9
   integrity sha512-kgenn5+pctVlJg8s1FOAm9KuZLRZvkBTMMGJvTTcvNTmnFIHVVYzYfA2Eg+yVefzsC8/cSZGKKJ0kLf8I+mQyw==
   dependencies:
     "@docusaurus/plugin-content-docs" "^2 || ^3"
@@ -4146,11 +4142,7 @@ combine-promises@^1.1.0:
 
 comlink@^4.4.2:
   version "4.4.2"
-<<<<<<< HEAD
-  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
-=======
   resolved "https://registry.npmmirror.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
->>>>>>> 80e7f8002ed39a2695b6cd492e48a984a2715ef9
   integrity sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==
 
 comma-separated-tokens@^2.0.0:


### PR DESCRIPTION
improvement GitHub Action behavior:

- Separate testing and deployment; `write` permissions are not required during testing.
-  Add `concurrency.cancel-in-progress: true` to both workflows to ensure that they only run the latest content and do not wait for old tasks.
- Configure yarn dependency caching to simplify work tasks and slightly improve CI execution efficiency.
- Use `yarn install --frozen-lockfile` instead of `yarn install` to adapt to the CI environment. ([Reference](https://classic.yarnpkg.com/en/docs/cli/install))