### PR TITLE
feat(docs): add recent updates page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -70,6 +70,7 @@ const config = {
   ],
 
   plugins:[
+    require.resolve('./plugins/recent-updates'),
     [
       'content-docs',
       {
@@ -112,6 +113,11 @@ const config = {
         {
           type: 'localeDropdown',
           position: 'left',
+        },
+        {
+          to: '/recent-updates',
+          position: 'left',
+          label: 'Recent updates',
         },
         {
           type: "search",

--- a/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,6 @@
+{
+  "item.label.Recent updates": {
+    "message": "最近更新",
+    "description": "最近更新页面的导航栏标签"
+  }
+}

--- a/plugins/recent-updates/index.js
+++ b/plugins/recent-updates/index.js
@@ -1,0 +1,149 @@
+const {execFileSync} = require('node:child_process');
+
+const CONTENT_PATHS = [
+  {
+    prefix: 'i18n/zh/docusaurus-plugin-content-docs/current/',
+    pluginId: 'default',
+  },
+  {
+    prefix: 'i18n/zh/docusaurus-plugin-content-faq/current/',
+    pluginId: 'faq',
+  },
+  {prefix: 'docs/', pluginId: 'default'},
+  {prefix: 'faq/', pluginId: 'faq'},
+];
+
+const GIT_PATHS = CONTENT_PATHS.map(({prefix}) => prefix.replace(/\/$/, ''));
+
+function readRecentCommits(siteDir) {
+  const format = '%x1e%H%x1f%cs%x1f%an%x1f%s';
+  const output = execFileSync(
+    'git',
+    [
+      'log',
+      '--no-merges',
+      '--diff-filter=AMR',
+      '-10',
+      '--date=short',
+      `--pretty=format:${format}`,
+      '--name-only',
+      '--',
+      ...GIT_PATHS,
+    ],
+    {
+      cwd: siteDir,
+      encoding: 'utf8',
+    },
+  );
+
+  return output
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map(parseCommit);
+}
+
+function parseCommit(record) {
+  const [header, ...files] = record.split('\n');
+  const [hash, date, author, subject] = header.split('\x1f');
+
+  return {
+    hash,
+    date,
+    author,
+    subject,
+    files: files.filter(Boolean),
+  };
+}
+
+function toDocumentIdentity(file) {
+  const contentPath = CONTENT_PATHS.find(({prefix}) => file.startsWith(prefix));
+  if (!contentPath || !/\.mdx?$/.test(file)) {
+    return undefined;
+  }
+
+  const id = file.slice(contentPath.prefix.length).replace(/\.mdx?$/, '');
+  return {
+    id,
+    pluginId: contentPath.pluginId,
+  };
+}
+
+function collectDocumentMetadata(allContent) {
+  const docsContent = allContent['docusaurus-plugin-content-docs'] ?? {};
+  const documents = new Map();
+
+  for (const [pluginId, content] of Object.entries(docsContent)) {
+    const loadedVersions = content.loadedVersions ?? [];
+    const currentVersion =
+      loadedVersions.find(({isLast}) => isLast) ?? loadedVersions[0];
+
+    for (const document of currentVersion?.docs ?? []) {
+      documents.set(`${pluginId}:${document.id}`, {
+        key: `${pluginId}:${document.id}`,
+        id: document.id,
+        title: document.title,
+        permalink: document.permalink,
+      });
+    }
+  }
+
+  return documents;
+}
+
+function enrichCommits(commits, documents, repositoryUrl) {
+  return commits.map((commit) => {
+    const changedDocuments = new Map();
+
+    for (const file of commit.files) {
+      const identity = toDocumentIdentity(file);
+      if (!identity) {
+        continue;
+      }
+
+      const key = `${identity.pluginId}:${identity.id}`;
+      const document = documents.get(key);
+      if (document) {
+        changedDocuments.set(key, document);
+      }
+    }
+
+    return {
+      hash: commit.hash,
+      shortHash: commit.hash.slice(0, 7),
+      subject: commit.subject,
+      author: commit.author,
+      date: commit.date,
+      commitUrl: `${repositoryUrl}/commit/${commit.hash}`,
+      documents: [...changedDocuments.values()],
+    };
+  });
+}
+
+module.exports = function recentUpdatesPlugin(context) {
+  const {siteDir, siteConfig} = context;
+  const repositoryUrl = `https://github.com/${siteConfig.organizationName}/${siteConfig.projectName}`;
+  let commits = [];
+
+  return {
+    name: 'recent-updates',
+    loadContent() {
+      commits = readRecentCommits(siteDir);
+      return commits;
+    },
+    async allContentLoaded({allContent, actions}) {
+      const documents = collectDocumentMetadata(allContent);
+      const updates = enrichCommits(commits, documents, repositoryUrl);
+      const updatesPath = await actions.createData('recent-updates.json', updates);
+
+      actions.addRoute({
+        path: `${context.baseUrl}recent-updates`,
+        component: '@site/src/components/RecentUpdatesPage/index.tsx',
+        exact: true,
+        modules: {
+          updates: updatesPath,
+        },
+      });
+    },
+  };
+};

--- a/src/components/RecentUpdatesPage/index.tsx
+++ b/src/components/RecentUpdatesPage/index.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import {useZh} from '@site/src/util/use-zh';
+import styles from './styles.module.css';
+
+type RecentDocument = {
+  key: string;
+  id: string;
+  title: string;
+  permalink: string;
+};
+
+type RecentUpdate = {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
+  commitUrl: string;
+  documents: RecentDocument[];
+};
+
+type RecentUpdatesPageProps = {
+  updates: RecentUpdate[];
+};
+
+const COPY = {
+  en: {
+    title: 'Recent updates',
+    description: 'The 10 latest commits that updated the Jimmer documentation.',
+    updatedBy: 'Updated by',
+    changedDocuments: 'Changed documents',
+    noDocuments: 'This commit only changed shared documentation content.',
+  },
+  zh: {
+    title: '最近更新',
+    description: '查看最近 10 次更新 Jimmer 文档的提交。',
+    updatedBy: '更新者',
+    changedDocuments: '涉及文档',
+    noDocuments: '本次提交仅更新了共享文档内容。',
+  },
+};
+
+function formatDate(date: string, isZh: boolean): string {
+  return new Intl.DateTimeFormat(isZh ? 'zh-CN' : 'en-US', {
+    year: 'numeric',
+    month: isZh ? 'numeric' : 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${date}T00:00:00Z`));
+}
+
+export default function RecentUpdatesPage({
+  updates,
+}: RecentUpdatesPageProps): JSX.Element {
+  const isZh = useZh();
+  const copy = isZh ? COPY.zh : COPY.en;
+
+  return (
+    <Layout title={copy.title} description={copy.description}>
+      <main className={styles.page}>
+        <div className="container">
+          <header className={styles.header}>
+            <p className={styles.eyebrow}>Jimmer documentation</p>
+            <h1>{copy.title}</h1>
+            <p>{copy.description}</p>
+          </header>
+
+          <div className={styles.timeline}>
+            {updates.map((update) => (
+              <article className={styles.update} key={update.hash}>
+                <div className={styles.marker} aria-hidden="true" />
+                <div className={styles.card}>
+                  <div className={styles.commitHeader}>
+                    <div>
+                      <time dateTime={update.date}>
+                        {formatDate(update.date, isZh)}
+                      </time>
+                      <h2>
+                        <a
+                          href={update.commitUrl}
+                          target="_blank"
+                          rel="noreferrer">
+                          {update.subject}
+                        </a>
+                      </h2>
+                    </div>
+                    <a
+                      className={styles.hash}
+                      href={update.commitUrl}
+                      target="_blank"
+                      rel="noreferrer">
+                      {update.shortHash}
+                    </a>
+                  </div>
+
+                  <p className={styles.author}>
+                    {copy.updatedBy} <strong>{update.author}</strong>
+                  </p>
+
+                  <div className={styles.documents}>
+                    <span className={styles.documentsLabel}>
+                      {copy.changedDocuments}
+                    </span>
+                    {update.documents.length > 0 ? (
+                      <div className={styles.documentLinks}>
+                        {update.documents.map((document) => (
+                          <Link key={document.key} to={document.permalink}>
+                            {document.title}
+                          </Link>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className={styles.emptyDocuments}>{copy.noDocuments}</p>
+                    )}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/components/RecentUpdatesPage/styles.module.css
+++ b/src/components/RecentUpdatesPage/styles.module.css
@@ -1,0 +1,202 @@
+.page {
+  min-height: calc(100vh - var(--ifm-navbar-height));
+  padding: 4rem 0 5rem;
+  background:
+    radial-gradient(circle at 50% 0, rgb(46 133 85 / 10%), transparent 28rem),
+    var(--ifm-background-color);
+}
+
+.header {
+  max-width: 48rem;
+  margin: 0 auto 3.5rem;
+  text-align: center;
+}
+
+.header h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2.25rem, 6vw, 3.75rem);
+  letter-spacing: -0.04em;
+}
+
+.header > p:last-child {
+  margin: 0;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 1.1rem;
+}
+
+.eyebrow {
+  margin-bottom: 0.75rem;
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.timeline {
+  position: relative;
+  max-width: 58rem;
+  margin: 0 auto;
+}
+
+.timeline::before {
+  position: absolute;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  left: 0.45rem;
+  width: 2px;
+  background: var(--ifm-color-emphasis-300);
+  content: '';
+}
+
+.update {
+  position: relative;
+  padding: 0 0 1.5rem 2.5rem;
+}
+
+.marker {
+  position: absolute;
+  top: 1.65rem;
+  left: 0;
+  width: 0.95rem;
+  height: 0.95rem;
+  border: 3px solid var(--ifm-background-color);
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px var(--ifm-color-primary);
+}
+
+.card {
+  padding: 1.5rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.9rem;
+  background: var(--ifm-card-background-color);
+  box-shadow: 0 8px 28px rgb(0 0 0 / 5%);
+}
+
+.commitHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.commitHeader time {
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.commitHeader h2 {
+  margin: 0.35rem 0 0;
+  font-size: 1.25rem;
+  line-height: 1.45;
+}
+
+.commitHeader h2 a {
+  color: var(--ifm-heading-color);
+}
+
+.commitHeader h2 a:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.hash {
+  flex: none;
+  padding: 0.25rem 0.55rem;
+  border-radius: 0.4rem;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8rem;
+}
+
+.hash:hover {
+  background: var(--ifm-color-primary-lightest);
+  color: var(--ifm-color-primary-darkest);
+  text-decoration: none;
+}
+
+.author {
+  margin: 0.75rem 0 1.25rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.9rem;
+}
+
+.documents {
+  padding-top: 1rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.documentsLabel {
+  display: block;
+  margin-bottom: 0.65rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.documentLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.documentLinks a {
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--ifm-color-primary-lightest);
+  border-radius: 999px;
+  background: rgb(46 133 85 / 8%);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.documentLinks a:hover {
+  background: rgb(46 133 85 / 15%);
+  text-decoration: none;
+}
+
+.emptyDocuments {
+  margin: 0;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 576px) {
+  .page {
+    padding: 2.5rem 0 3.5rem;
+  }
+
+  .header {
+    margin-bottom: 2.5rem;
+  }
+
+  .update {
+    padding-left: 1.75rem;
+  }
+
+  .timeline::before {
+    left: 0.3rem;
+  }
+
+  .marker {
+    top: 1.4rem;
+    left: -0.15rem;
+  }
+
+  .card {
+    padding: 1.15rem;
+  }
+
+  .commitHeader {
+    display: block;
+  }
+
+  .hash {
+    display: inline-block;
+    margin-top: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Need

Readers currently have no quick way to discover the documentation changed by recent commits.

## Changes

- generate the 10 latest non-merge documentation commits from Git history during the Docusaurus build
- link each commit to the affected documents using locale-aware Docusaurus metadata
- add a responsive Recent updates page and navbar entry for English and Chinese

## Verification

- built all locales with Docusaurus under Node.js 18
- verified English and Chinese pages in the browser
- verified the 390px mobile layout has no horizontal overflow